### PR TITLE
fix bug where script loads before rest of the page

### DIFF
--- a/yt_no_recommendations.js
+++ b/yt_no_recommendations.js
@@ -8,17 +8,20 @@ const MODE = "debugging";
 function hideElements(mode) {
     const startPageSuggestions = document.getElementById("contents");
     const videoPlayerSuggestions = document.querySelector("#secondary");
-    
+
     const elementsToHide = [startPageSuggestions, videoPlayerSuggestions];
-    
+
     if (mode === "debugging") {
         console.log(elementsToHide);
     }
-    
+
     const numElementsToHide = elementsToHide.length;
     for (let i = 0; i < numElementsToHide; i++) {
-        elementsToHide[i].style.display = "none";
+        const element = elementsToHide[i];
+        if (element !== null) {
+            element.style.display = "none";
+        }
     }
 }
 
-hideElements(MODE);
+window.onload(() => hideElements(MODE));


### PR DESCRIPTION
This PR fixes the major bug where the content script is loader before the DOM is fully there. This leads to big inconsistencies in terms of whether the sidebar/recommendations will be hidden or not.